### PR TITLE
Compilation into VM algebra and interpretation for CharModule

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -62,7 +62,7 @@ object BuildHelper {
         Seq("-Xexperimental") ++ stdOptsUpto212
     }
 
-  val zioVersion = "1.0.0-RC17"
+  val zioVersion = "1.0.0-RC18-2"
 
   def buildInfoSettings(packageName: String) =
     Seq(

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -32,7 +32,7 @@ trait BitCodecModule extends CodecModule {
         case CodecVM.CheckSet(s) =>
           stack.push(s.contains(stack.pop()).asInstanceOf[AnyRef])
 
-        case CodecVM.JumpCond(ifEqual, otherwise) =>
+        case CodecVM.JumpEq(ifEqual, otherwise) =>
           if (stack.pop().eq(stack.pop())) i = ifEqual else i = otherwise
 
         case CodecVM.Construct1(f) =>

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -7,7 +7,7 @@ import zio.internal.Stack
 trait BitCodecModule extends CodecModule {
   type Input = Boolean
 
-  val uint16: Codec[Int] = consume.repN(16).map(Equiv.UInt16)
+  val uint16: Codec[Int] = consume.repN(16).map(Equiv.Bits.UInt16)
 
   @silent
   private def compileCodec[A](codec: Codec[A]): Array[CodecVM] = ???

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -21,7 +21,7 @@ trait BitCodecModule extends CodecModule {
     var r0: AnyRef      = null.asInstanceOf[AnyRef]
 
     while (i < codec.length) {
-      val instr = codec(i)
+      val instr: CodecVM = codec(i)
       instr match {
         case CodecVM.Push(value) =>
           stack.push(value)
@@ -32,14 +32,14 @@ trait BitCodecModule extends CodecModule {
         case CodecVM.CheckSet(s) =>
           stack.push(s.contains(stack.pop()).asInstanceOf[AnyRef])
 
-        case CodecVM.CondJump(ifEqual, otherwise) =>
+        case CodecVM.JumpCond(ifEqual, otherwise) =>
           if (stack.pop().eq(stack.pop())) i = ifEqual else i = otherwise
 
         case CodecVM.Construct1(f) =>
-          f(stack.pop())
+          stack.push(f(stack.pop()))
 
         case CodecVM.Construct2(f) =>
-          f(stack.pop(), stack.pop())
+          stack.push(f(stack.pop(), stack.pop()))
 
         case CodecVM.Fail(err) =>
           return Left(DecodeError(err, i))

--- a/src/main/scala/zio/codec/CharCodecModule.scala
+++ b/src/main/scala/zio/codec/CharCodecModule.scala
@@ -1,0 +1,20 @@
+package zio.codec
+
+import zio.Chunk
+
+trait CharCodecModule extends CodecModule {
+  type Input = Char
+
+  def decoder[A](codec: Codec[A]): Chunk[Input] => Either[DecodeError, (Int, A)] = {
+    val compiled = compileCodec(codec)
+    interpret(_, compiled).asInstanceOf[Either[DecodeError, (Int, A)]]
+  }
+
+  def encoder[A](codec: Codec[A]): A => Either[EncodeError, Chunk[Input]] = ???
+
+  def printer[A](codec: Codec[A]): List[String] = ???
+
+  private def compileCodec[A](codec: Codec[A]): Array[CodecVM] = ???
+
+  private def interpret(input: Chunk[Input], codec: Array[CodecVM]): Either[DecodeError, (Int, Any)] = ???
+}

--- a/src/main/scala/zio/codec/CharCodecModule.scala
+++ b/src/main/scala/zio/codec/CharCodecModule.scala
@@ -1,12 +1,14 @@
 package zio.codec
 
 import zio.Chunk
+import zio.internal.Stack
 
 trait CharCodecModule extends CodecModule {
   type Input = Char
 
   def decoder[A](codec: Codec[A]): Chunk[Input] => Either[DecodeError, (Int, A)] = {
-    val compiled = compileCodec(codec)
+    val compiled = compileCodec(codec, 0)
+//    println(compiled.zipWithIndex.map { case (o, i) => i.toString.reverse.padTo(3, '0').reverse + ": " + o }.mkString("", "\n", "\n"))
     interpret(_, compiled).asInstanceOf[Either[DecodeError, (Int, A)]]
   }
 
@@ -14,7 +16,184 @@ trait CharCodecModule extends CodecModule {
 
   def printer[A](codec: Codec[A]): List[String] = ???
 
-  private def compileCodec[A](codec: Codec[A]): Array[CodecVM] = ???
+  private case object NoValue
 
-  private def interpret(input: Chunk[Input], codec: Array[CodecVM]): Either[DecodeError, (Int, Any)] = ???
+  private def compileCodec[A](codec: Codec[A], offset: Int): Array[CodecVM] = {
+    import Codec._
+    val VM = CodecVM
+
+    codec match {
+      case Produce(a) =>
+        Array(
+          VM.Push(a.asInstanceOf[AnyRef])
+        )
+
+      case Fail(error) =>
+        Array(
+          VM.Fail(error)
+        )
+
+      case Consume =>
+        Array(
+          VM.Read(None, None)
+        )
+
+      case Map(_, value) =>
+        // todo
+        compileCodec(value(), offset) ++ Array[CodecVM](
+          )
+
+      case Filter(value, in, not) =>
+        val program = compileCodec(value(), offset) ++ Array(
+          VM.Duplicate,
+          VM.CheckSet(in.map(_.asInstanceOf[AnyRef])),
+          VM.Push((!not).asInstanceOf[AnyRef])
+        )
+
+        val lMismatch = offset + program.length + 1
+        val lMatch    = offset + program.length + 3
+
+        program ++ Array(
+          VM.JumpCond(lMatch, lMismatch),
+          VM.Pop,
+          VM.Push(NoValue),
+          VM.Noop // todo: not needed
+        )
+
+      case Zip(left, right) =>
+        val program = compileCodec(left(), offset)
+        program ++ compileCodec(right(), offset + program.length) ++ Array(
+          VM.Construct2(Tuple2.apply)
+        )
+
+      case Alt(_, _) =>
+        // todo
+        ???
+//        println(right)
+//        compileCodec(left(), offset)
+
+      case Rep(value, None, None) =>
+        val program = Array(
+          VM.Push(List.empty[AnyRef]),
+          VM.FramePush
+        ) ++ compileCodec(value(), offset + 2) ++ Array(
+          VM.Duplicate,
+          VM.Push(NoValue)
+        )
+
+        val lRepeat = offset + 1
+        val lAccum  = offset + program.length + 1
+        val lFinish = offset + program.length + 4
+
+        program ++ Array(
+          VM.JumpCond(lFinish, lAccum),
+          VM.FramePop,
+          VM.Construct2((l, a) => a :: l.asInstanceOf[List[AnyRef]]),
+          VM.Jump(lRepeat),
+          VM.FrameLoad,
+          VM.Pop,
+          VM.Construct1(l => l.asInstanceOf[List[AnyRef]].reverse) // todo: work with array?
+        )
+
+      case Rep(_, _, _) =>
+        ???
+    }
+  }
+
+  private def interpret(input: Chunk[Input], codec: Array[CodecVM]): Either[DecodeError, (Int, Any)] = {
+    import CodecVM._
+
+    val stack: Stack[AnyRef] = Stack()
+    var i: Int               = 0
+
+    val inputStack: Stack[AnyRef] = Stack()
+    var inputIndex: Int           = -1
+    val inputLength: Int          = input.length
+
+    var r0: AnyRef = null.asInstanceOf[AnyRef]
+
+    while (i < codec.length) {
+      val instr: CodecVM = codec(i)
+      instr match {
+        case Push(value) =>
+          stack.push(value)
+          i += 1
+
+        case Read(None, None) =>
+          inputIndex += 1
+          if (inputIndex < inputLength) {
+            stack.push(input(inputIndex).asInstanceOf[AnyRef])
+            i += 1
+          } else {
+            return Left(DecodeError("EOI", i))
+          }
+
+        case Read(_, _) =>
+          ???
+
+        case CheckSet(s) =>
+          val v1 = stack.pop()
+          println(v1.toString + " in " + s) // todo
+          stack.push(s.contains(v1).asInstanceOf[AnyRef])
+          i += 1
+
+        case Jump(to) =>
+          i = to
+
+        case JumpCond(ifEqual, otherwise) =>
+          if (stack.pop().eq(stack.pop())) i = ifEqual else i = otherwise
+
+        case Construct1(f) =>
+          stack.push(f(stack.pop()))
+          i += 1
+
+        case Construct2(f) =>
+          val arg2 = stack.pop()
+          val arg1 = stack.pop()
+          stack.push(f(arg1, arg2))
+          i += 1
+
+        case Fail(err) =>
+          return Left(DecodeError(err, inputIndex))
+
+        case Pop =>
+          stack.pop()
+          i += 1
+
+        case Noop =>
+          i += 1
+
+        case Duplicate =>
+          stack.push(stack.peek())
+          i += 1
+
+        case StoreRegister0 =>
+          r0 = stack.pop()
+          i += 1
+
+        case LoadRegister0 =>
+          stack.push(r0)
+          i += 1
+
+        case FramePush =>
+          inputStack.push(inputIndex.asInstanceOf[AnyRef])
+          i += 1
+
+        case FramePop =>
+          inputStack.pop()
+          i += 1
+
+        case FrameLoad =>
+          inputIndex = inputStack.pop().asInstanceOf[Int]
+          i += 1
+      }
+
+//      println(instr.toString.padTo(20, ' ') + ": " + stack.peekOrElse("EMPTY"))
+    }
+
+    stack.pop() match {
+      case null => Left(DecodeError("bug in our implementation, please report to us", 0))
+      case v    => Right((inputIndex, v))
+    }
+  }
 }

--- a/src/main/scala/zio/codec/CodecModule.scala
+++ b/src/main/scala/zio/codec/CodecModule.scala
@@ -58,7 +58,7 @@ trait CodecModule {
   object Codec {
     private[zio] sealed case class Produce[A](a: A)                                                  extends Codec[A]
     private[zio] sealed case class Fail[A](error: String)                                            extends Codec[A]
-    private[zio] case object Consume                                                                 extends Codec[Input]
+    private[zio]       case object Consume                                                           extends Codec[Input]
     private[zio] sealed case class Map[A, B](equiv: Equiv[A, B], value: () => Codec[A])              extends Codec[B]
     private[zio] sealed case class Filter[A](value: () => Codec[A], filter: Set[A], not: Boolean)    extends Codec[A]
     private[zio] sealed case class Zip[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[(A, B)]

--- a/src/main/scala/zio/codec/CodecModule.scala
+++ b/src/main/scala/zio/codec/CodecModule.scala
@@ -11,7 +11,8 @@ trait CodecModule {
 
     def map[B](equiv: Equiv[A, B]): Codec[B] = Map(equiv, () => self)
 
-    def ignore(a: A): Codec[Unit] = map(Equiv.Ignore(a))
+    def ignore(a: A): Codec[Unit]   = map(Equiv.Ignore(a))
+    def as[B](b: B, a: A): Codec[B] = map(Equiv.As(b, a))
 
     def filter(set: Set[A]): Codec[A]                                = Filter(() => self, set, FilterMode.Inside)
     def filterNot(set: Set[A]): Codec[A]                             = Filter(() => self, set, FilterMode.Outside)

--- a/src/main/scala/zio/codec/CodecModule.scala
+++ b/src/main/scala/zio/codec/CodecModule.scala
@@ -11,14 +11,17 @@ trait CodecModule {
 
     def map[B](equiv: Equiv[A, B]): Codec[B] = Map(equiv, () => self)
 
-    def filter(set: Set[A]): Codec[A]                                = Filter(() => self, set)
+    def ignore(a: A): Codec[Unit] = map(Equiv.Ignore(a))
+
+    def filter(set: Set[A]): Codec[A]                                = Filter(() => self, set, not = false)
+    def filterNot(set: Set[A]): Codec[A]                             = Filter(() => self, set, not = true)
     def filter(f: A => Boolean)(implicit e: Enumerable[A]): Codec[A] = filter(e.enumerate.filter(f).toSet)
 
     def zip[B](that: => Codec[B]): Codec[(A, B)] = Zip(() => self, () => that)
     def ~[B](that: => Codec[B]): Codec[(A, B)]   = zip(that)
 
     def zipLeft[B](that: => Codec[B], b: B): Codec[A] = zip(that).map(Equiv.Left(b))
-    def <~[B](that: => Codec[B], b: B): Codec[A]      = zipLeft(that, b)
+    def <~[B](b: B, that: => Codec[B]): Codec[A]      = zipLeft(that, b)
 
     def zipRight[B](a: A, that: => Codec[B]): Codec[B] = zip(that).map(Equiv.Right(a))
 
@@ -57,7 +60,7 @@ trait CodecModule {
     private[zio] sealed case class Fail[A](error: String)                                            extends Codec[A]
     private[zio] case object Consume                                                                 extends Codec[Input]
     private[zio] sealed case class Map[A, B](equiv: Equiv[A, B], value: () => Codec[A])              extends Codec[B]
-    private[zio] sealed case class Filter[A](value: () => Codec[A], filter: Set[A])                  extends Codec[A]
+    private[zio] sealed case class Filter[A](value: () => Codec[A], filter: Set[A], not: Boolean)    extends Codec[A]
     private[zio] sealed case class Zip[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[(A, B)]
     private[zio] sealed case class Alt[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[Either[A, B]]
     private[zio] sealed case class Rep[A](value: () => Codec[A], min: Option[Int], max: Option[Int]) extends Codec[Chunk[A]]

--- a/src/main/scala/zio/codec/CodecModule.scala
+++ b/src/main/scala/zio/codec/CodecModule.scala
@@ -29,6 +29,7 @@ trait CodecModule {
     def orElseEither[B](that: => Codec[B]): Codec[Either[A, B]] = Alt(() => self, () => that)
     def |[B](that: => Codec[B]): Codec[Either[A, B]]            = orElseEither(that)
 
+    // todo: N should be natural
     def repRange(range: Range): Codec[Chunk[A]] = Rep(() => self, Some(range.start), Some(range.end))
     def repN(n: Int): Codec[Chunk[A]]           = Rep(() => self, Some(n), Some(n))
     def rep: Codec[Chunk[A]]                    = Rep(() => self, None, None)

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -1,17 +1,22 @@
 package zio.codec
 
-sealed trait CodecVM {}
+sealed trait CodecVM
 
 object CodecVM {
-  private[zio] final case class Push(value: AnyRef)                       extends CodecVM
-  private[zio] final case class Read(min: Option[Int], max: Option[Int])  extends CodecVM // read from input
-  private[zio] final case class CheckSet(s: Set[AnyRef])                  extends CodecVM // test head of the stack is in bitset, push the result as boolean on the stack
-  private[zio] final case class CondJump(ifEqual: Int, otherwise: Int)    extends CodecVM
+  private[zio] final case class Read(min: Option[Int], max: Option[Int])  extends CodecVM // read from input, push to stack
+  private[zio] final case class Push(value: AnyRef)                       extends CodecVM // push value
+  private[zio] final case class CheckSet(s: Set[AnyRef])                  extends CodecVM // pot 1, test value is in set, push the result as boolean on the stack
+  private[zio] final case class Jump(to: Int)                             extends CodecVM // unconditional jump to new address
+  private[zio] final case class JumpCond(ifEqual: Int, otherwise: Int)    extends CodecVM // pop 2 things and jump to new address
   private[zio] final case class Construct1(f: AnyRef => AnyRef)           extends CodecVM // pop 1 thing, pass to f and push to stack
   private[zio] final case class Construct2(f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop 2 things, pass to f and push to stack
   private[zio] final case class Fail(err: String)                         extends CodecVM
+  private[zio] final case object Pop                                      extends CodecVM // pop 1 thing
+  private[zio] final case object Noop                                     extends CodecVM // do nothing
+  private[zio] final case object Duplicate                                extends CodecVM // duplicate stack head
   private[zio] final case object StoreRegister0                           extends CodecVM // pop 1 thing from stack and store in var 0
-//  final case class Loop(test: CodecVM, body: CodecVM) extends CodecVM // convention: push a boolean to indicate if need to continue
-//  final case class Try(body: CodecVM, recover: CodecVM) extends CodecVM
-
+  private[zio] final case object LoadRegister0                            extends CodecVM // push var 0
+  private[zio] final case object FramePush                                extends CodecVM // push read index to stack
+  private[zio] final case object FramePop                                 extends CodecVM // pop read index from stack
+  private[zio] final case object FrameLoad                                extends CodecVM // pop read index from stack and assign to read index
 }

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -7,7 +7,7 @@ object CodecVM {
   private[zio] final case class Push(value: AnyRef)                       extends CodecVM // push value
   private[zio] final case class CheckSet(s: Set[AnyRef])                  extends CodecVM // pot 1, test value is in set, push the result as boolean on the stack
   private[zio] final case class Jump(to: Int)                             extends CodecVM // unconditional jump to new address
-  private[zio] final case class JumpCond(ifEqual: Int, otherwise: Int)    extends CodecVM // pop 2 things and jump to new address
+  private[zio] final case class JumpEq(ifEqual: Int, otherwise: Int)      extends CodecVM // pop 2 things and jump to new address
   private[zio] final case class Construct1(f: AnyRef => AnyRef)           extends CodecVM // pop 1 thing, pass to f and push to stack
   private[zio] final case class Construct2(f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop 2 things, pass to f and push to stack
   private[zio] final case class Fail(err: String)                         extends CodecVM
@@ -16,6 +16,7 @@ object CodecVM {
   private[zio] final case object Duplicate                                extends CodecVM // duplicate stack head
   private[zio] final case object StoreRegister0                           extends CodecVM // pop 1 thing from stack and store in var 0
   private[zio] final case object LoadRegister0                            extends CodecVM // push var 0
+  private[zio] final case object Add                                      extends CodecVM // pop 2 things, add, push result
   private[zio] final case object FramePush                                extends CodecVM // push read index to stack
   private[zio] final case object FramePop                                 extends CodecVM // pop read index from stack
   private[zio] final case object FrameLoad                                extends CodecVM // pop read index from stack and assign to read index

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -12,11 +12,10 @@ object CodecVM {
   private[zio] final case class Construct2(f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop 2 things, pass to f and push to stack
   private[zio] final case class Fail(err: String)                         extends CodecVM
   private[zio] final case object Pop                                      extends CodecVM // pop 1 thing
-  private[zio] final case object Noop                                     extends CodecVM // do nothing
   private[zio] final case object Duplicate                                extends CodecVM // duplicate stack head
   private[zio] final case object StoreRegister0                           extends CodecVM // pop 1 thing from stack and store in var 0
   private[zio] final case object LoadRegister0                            extends CodecVM // push var 0
-  private[zio] final case object Add                                      extends CodecVM // pop 2 things, add, push result
+  private[zio] final case object IAdd                                     extends CodecVM // pop 2 integers, add, push result
   private[zio] final case object FramePush                                extends CodecVM // push read index to stack
   private[zio] final case object FramePop                                 extends CodecVM // pop read index from stack
   private[zio] final case object FrameLoad                                extends CodecVM // pop read index from stack and assign to read index

--- a/src/main/scala/zio/codec/Equiv.scala
+++ b/src/main/scala/zio/codec/Equiv.scala
@@ -8,7 +8,8 @@ object Equiv {
   final case class Left[A, B](b: B)  extends Equiv[(A, B), A]
   final case class Right[A, B](a: A) extends Equiv[(A, B), B]
 
-  final case class Ignore[A, Unit](a: A) extends Equiv[A, Unit]
+  final case class Ignore[A](a: A)      extends Equiv[A, Unit]
+  final case class As[A, B](b: B, a: A) extends Equiv[A, B]
 
   object Bits {
     final case object UInt16 extends Equiv[Chunk[Boolean], Int]

--- a/src/main/scala/zio/codec/Equiv.scala
+++ b/src/main/scala/zio/codec/Equiv.scala
@@ -3,9 +3,18 @@ package zio.codec
 import zio.Chunk
 
 sealed trait Equiv[A, B]
+
 object Equiv {
   final case class Left[A, B](b: B)  extends Equiv[(A, B), A]
   final case class Right[A, B](a: A) extends Equiv[(A, B), B]
 
-  final case object UInt16 extends Equiv[Chunk[Boolean], Int]
+  final case class Ignore[A, Unit](a: A) extends Equiv[A, Unit]
+
+  object Bits {
+    final case object UInt16 extends Equiv[Chunk[Boolean], Int]
+  }
+
+  object Chars {
+    final case object String extends Equiv[Chunk[Char], String]
+  }
 }

--- a/src/test/scala/zio/codec/examples/CodecJsonTest.scala
+++ b/src/test/scala/zio/codec/examples/CodecJsonTest.scala
@@ -25,6 +25,7 @@ object CodecJsonTest {
   // todo: val field: Codec[(String, Val)] = (string <~ (':', colon)) ~ js
   val field: Codec[(String, String)] = (string <~ (':', colon)) ~ string
 
+//  val dec: Chunk[Char] => Either[DecodeError, (Int, Unit)] = decoder(spacing)
   val dec: Chunk[Char] => Either[DecodeError, (Int, (String, String))] = decoder(field)
 
   def main(args: Array[String]): Unit =

--- a/src/test/scala/zio/codec/examples/CodecJsonTest.scala
+++ b/src/test/scala/zio/codec/examples/CodecJsonTest.scala
@@ -25,9 +25,10 @@ object CodecJsonTest {
   // todo: val field: Codec[(String, Val)] = (string <~ (':', colon)) ~ js
   val field: Codec[(String, String)] = (string <~ (':', colon)) ~ string
 
-//  val dec: Chunk[Char] => Either[DecodeError, (Int, Unit)] = decoder(spacing)
   val dec: Chunk[Char] => Either[DecodeError, (Int, (String, String))] = decoder(field)
 
   def main(args: Array[String]): Unit =
+    //println(dec(Chunk.fromArray(""""pro""".toCharArray)))
+    //println()
     println(dec(Chunk.fromArray(""" "prop1": "val1" """.toCharArray)))
 }

--- a/src/test/scala/zio/codec/examples/CodecJsonTest.scala
+++ b/src/test/scala/zio/codec/examples/CodecJsonTest.scala
@@ -41,13 +41,16 @@ object CodecJsonTest {
   // todo: val field: Codec[(String, Val)] = (string <~ (':', colon)) ~ js
   val field: Codec[(String, String)] = (string <~ (':', colon)) ~ string
 
-  val dec: Chunk[Char] => Either[DecodeError, (Int, (String, String))] = decoder(field)
+  val js: Codec[Either[(String, String), Js.Null.type]] =
+    (spacing, ()) ~> (field | `null`) <~ ((), spacing)
 
-  val test: Chunk[Char] => Either[DecodeError, (Int, Js.Null.type)] = decoder(`null`)
+  val dec: Chunk[Char] => Either[DecodeError, (Int, Either[(String, String), Js.Null.type])] = decoder(js)
 
-  def main(args: Array[String]): Unit =
-    //println(dec(Chunk.fromArray(""""pro""".toCharArray)))
-    //println()
+  def main(args: Array[String]): Unit = {
+    println(dec(Chunk.fromArray("""kkk""".toCharArray)))
+    println(dec(Chunk.fromArray(""""pro""".toCharArray)))
+
+    println(dec(Chunk.fromArray(""" null """.toCharArray)))
     println(dec(Chunk.fromArray(""" "prop1": "val1" """.toCharArray)))
-//    println(test(Chunk.fromArray("""null""".toCharArray)))
+  }
 }

--- a/src/test/scala/zio/codec/examples/CodecJsonTest.scala
+++ b/src/test/scala/zio/codec/examples/CodecJsonTest.scala
@@ -1,0 +1,32 @@
+package zio.codec.examples
+
+import zio.Chunk
+import zio.codec.{ CharCodecModule, DecodeError, Equiv }
+
+object CodecJsonTest {
+
+  object JsonCodec extends CharCodecModule
+
+  import Equiv._
+  import JsonCodec._
+
+  def char(c: Char): Codec[Char] =
+    consume.filter(Set(c))
+
+  val colon: Codec[Char] = char(':')
+  val quote: Codec[Char] = char('"')
+
+  val spacing: Codec[Unit] =
+    consume.filter(Set(' ', '\n', '\r')).rep.ignore(Chunk.empty)
+
+  val string: Codec[String] =
+    ((spacing ~ quote, ((), '"')) ~> consume.filterNot(Set('\"', '\\')).rep <~ ('"', quote)).map(Chars.String)
+
+  // todo: val field: Codec[(String, Val)] = (string <~ (':', colon)) ~ js
+  val field: Codec[(String, String)] = (string <~ (':', colon)) ~ string
+
+  val dec: Chunk[Char] => Either[DecodeError, (Int, (String, String))] = decoder(field)
+
+  def main(args: Array[String]): Unit =
+    println(dec(Chunk.fromArray(""" "prop1": "val1" """.toCharArray)))
+}


### PR DESCRIPTION
Connects #7 
Connects #8 
Connects #9 

- Compilation into `CodecVM` algebra is implemented for `Codec[Char]`.
- Interpretation of programs expressed as `CodecVM` is implemented for `Codec[Char]`

There is one unsupported operation `Rep(range)` at the moment.