### PR TITLE
JVM ByteCode compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,10 @@ lazy val codec =
     .settings(buildInfoSettings("zio.codec"))
     .settings(
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio"          % zioVersion,
-        "dev.zio" %% "zio-test"     % zioVersion % Test,
-        "dev.zio" %% "zio-test-sbt" % zioVersion % Test
+        "org.ow2.asm" % "asm"           % "8.0.1",
+        "dev.zio"     %% "zio"          % zioVersion,
+        "dev.zio"     %% "zio-test"     % zioVersion % Test,
+        "dev.zio"     %% "zio-test-sbt" % zioVersion % Test
       ),
       testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
     )

--- a/build.sbt
+++ b/build.sbt
@@ -46,6 +46,8 @@ lazy val codec =
         "dev.zio"     %% "zio-test"     % zioVersion % Test,
         "dev.zio"     %% "zio-test-sbt" % zioVersion % Test
       ),
+      fork in Test := true,
+      parallelExecution in Test := false,
       testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework"))
     )
     .enablePlugins(BuildInfoPlugin)

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -35,10 +35,10 @@ trait BitCodecModule extends CodecModule {
         case CodecVM.ACmpEq(address) =>
           if (stack.pop().eq(stack.pop())) i = address.address else i += 1
 
-        case CodecVM.Construct1(f) =>
+        case CodecVM.Call1(f) =>
           stack.push(f(stack.pop()))
 
-        case CodecVM.Construct2(f) =>
+        case CodecVM.Call2(f) =>
           stack.push(f(stack.pop(), stack.pop()))
 
         case CodecVM.Fail(err) =>

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -26,7 +26,7 @@ trait BitCodecModule extends CodecModule {
         case CodecVM.Push(value) =>
           stack.push(value)
 
-        case CodecVM.Read(min, max) =>
+        case CodecVM.InputRead(min, max) =>
 //          if (inputIndex + min < input.length
 
         case CodecVM.CheckSet(s) =>

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -30,7 +30,7 @@ trait BitCodecModule extends CodecModule {
 //          if (inputIndex + min < input.length
 
         case CodecVM.CheckSet(s) =>
-          stack.push(s.contains(stack.pop()).asInstanceOf[AnyRef])
+          stack.push(s.set.contains(stack.pop()).asInstanceOf[AnyRef])
 
         case CodecVM.ACmpEq(address) =>
           if (stack.pop().eq(stack.pop())) i = address.address else i += 1

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -38,9 +38,6 @@ trait BitCodecModule extends CodecModule {
         case CodecVM.Call1(f) =>
           stack.push(f(stack.pop()))
 
-        case CodecVM.Call2(f) =>
-          stack.push(f(stack.pop(), stack.pop()))
-
         case CodecVM.Fail(err) =>
           return Left(DecodeError(err, i))
 

--- a/src/main/scala/zio/codec/BitCodecModule.scala
+++ b/src/main/scala/zio/codec/BitCodecModule.scala
@@ -35,9 +35,6 @@ trait BitCodecModule extends CodecModule {
         case CodecVM.ACmpEq(address) =>
           if (stack.pop().eq(stack.pop())) i = address.address else i += 1
 
-        case CodecVM.Call1(f) =>
-          stack.push(f(stack.pop()))
-
         case CodecVM.Fail(err) =>
           return Left(DecodeError(err, i))
 

--- a/src/main/scala/zio/codec/CharCodecModule.scala
+++ b/src/main/scala/zio/codec/CharCodecModule.scala
@@ -8,6 +8,8 @@ import org.objectweb.asm.{ ClassWriter, Label, MethodVisitor, Opcodes }
 import zio.Chunk
 import zio.internal.Stack
 
+import scala.runtime.BoxedUnit
+
 trait CharCodecModule extends CodecModule {
   type Input = Char
 
@@ -22,7 +24,7 @@ trait CharCodecModule extends CodecModule {
     consume.filter((begin to end).toSet)
 
   def decoder[A](codec: Codec[A]): Chunk[Input] => Either[DecodeError, (Int, A)] = {
-    val (program, _, _) = compileCodec(codec)
+    val CodecCompilationResult(program, _, _, _) = compileCodec(codec)
 //    println(program.zipWithIndex.map { case (o, i) => i.toString.reverse.padTo(3, '0').reverse + ": " + o }.mkString("", "\n", "\n"))
     interpret(_, program).asInstanceOf[Either[DecodeError, (Int, A)]]
   }
@@ -33,22 +35,28 @@ trait CharCodecModule extends CodecModule {
 
   // todo: rename functions, fix signature
   def decoder2[A](codec: Codec[A]): Chunk[Input] => (Int, A) = {
-    val (program, labels, lookups) = compileCodec(codec)
+    val CodecCompilationResult(program, labels, values, lookups) = compileCodec(codec)
     println(program.zipWithIndex.map { case (o, i) => i.toString.reverse.padTo(3, '0').reverse + ": " + o }
       .mkString("", "\n", "\n"))
 
-    val (name, bytes) = compileCodecVM(program, labels, lookups)
+    val (name, bytes) = compileCodecVM(program, labels, values, lookups)
     val method        = new ByteClassLoader().load(name, bytes)
 
     println(method)
     println()
 
-    s => (123, method.invoke(null, Array(NoValue) ++ lookups, s.toArray).asInstanceOf[A])
+    s => (123, method.invoke(null, values, lookups, s.toArray).asInstanceOf[A])
   }
 
   private case object NoValue
+  private case class CodecCompilationResult(
+    program: Array[CodecVM],
+    addresses: Map[Int, Int],
+    values: Array[AnyRef],
+    lookups: Array[java.util.HashSet[Any]]
+  )
 
-  private def compileCodec[A](codec: Codec[A]): (Array[CodecVM], Map[Int, Int], Array[java.util.HashSet[Any]]) = {
+  private def compileCodec[A](codec: Codec[A]): CodecCompilationResult = {
     import Codec.FilterMode._
 
     val VM = CodecVM
@@ -74,6 +82,25 @@ trait CharCodecModule extends CodecModule {
       VM.ASet(idx, filter.filter.asInstanceOf[Set[Any]])
     }
 
+    val v0                    = VM.AValue(0, NoValue)
+    val v1                    = VM.AValue(1, BoxedUnit.UNIT)
+    val v2                    = VM.AValue(2, None)
+    val v3                    = VM.AValue(3, Chunk.empty)
+    var valueCount: Int       = 4
+    var values: Array[AnyRef] = Array(NoValue, BoxedUnit.UNIT, None, Chunk.empty)
+    def newValue(value: AnyRef): VM.AValue =
+      value match {
+        case NoValue        => v0
+        case BoxedUnit.UNIT => v1
+        case None           => v2
+        case Chunk.empty    => v3
+        case v =>
+          val idx = valueCount
+          values = values :+ v
+          valueCount += 1
+          VM.AValue(idx, v)
+      }
+
     def compile[A0](codec: Codec[A0], offset: Int, chain: Map[AnyRef, (Int, Int)]): Array[CodecVM] = {
       chain
         .get(codec)
@@ -86,7 +113,7 @@ trait CharCodecModule extends CodecModule {
           codec match {
             case Codec.Produce(a) =>
               Array(
-                VM.Push(a.asInstanceOf[AnyRef])
+                VM.Push(newValue(a.asInstanceOf[AnyRef]))
               )
 
             case Codec.Fail(error) =>
@@ -104,15 +131,15 @@ trait CharCodecModule extends CodecModule {
                 VM.BeginMethod(name)
               ) ++ compile(map.value(), offset + 1, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val mapProgram: Array[CodecVM] = map.equiv match {
                 case Equiv.Left(_)      => Array(VM.Call1(_.asInstanceOf[(AnyRef, _)]._1))
                 case Equiv.Right(_)     => Array(VM.Call1(_.asInstanceOf[(_, AnyRef)]._2))
                 case Equiv.Merge()      => Array(VM.Call1(_.asInstanceOf[Either[AnyRef, AnyRef]].merge))
-                case Equiv.Ignore(_)    => Array(VM.Pop, VM.Push(().asInstanceOf[AnyRef]))
-                case Equiv.As(b, _)     => Array(VM.Pop, VM.Push(b.asInstanceOf[AnyRef]))
+                case Equiv.Ignore(_)    => Array(VM.Pop, VM.Push(newValue(BoxedUnit.UNIT)))
+                case Equiv.As(b, _)     => Array(VM.Pop, VM.Push(newValue(b.asInstanceOf[AnyRef])))
                 case Equiv.Chars.String => Array(VM.Call1(_.asInstanceOf[Chunk[Char]].mkString))
                 case Equiv.Bits.UInt16  => ???
 
@@ -132,7 +159,7 @@ trait CharCodecModule extends CodecModule {
                 VM.BeginMethod(name)
               ) ++ compile(value(), offset + 1, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val lMatch = newLabel(offset + program.length + 7)
@@ -148,7 +175,7 @@ trait CharCodecModule extends CodecModule {
                 VM.ICmpEq(lMatch),
 
                 VM.Pop,                          // mismatch
-                VM.Push(NoValue),
+                VM.Push(newValue(NoValue)),
                 VM.Return(name)                  // match, exit
               )
               // format: on
@@ -156,16 +183,16 @@ trait CharCodecModule extends CodecModule {
             case Codec.Zip(left, right) =>
               val programL = Array(
                 VM.BeginMethod(name),
-                VM.New(VM.AInstance(UUID.randomUUID(), "scala/Tuple2")),
+                VM.New(VM.ANew(UUID.randomUUID(), "scala/Tuple2")),
                 VM.Duplicate
               ) ++ compile(left(), offset + 3, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val programR = compile(right(), offset + programL.length + 1, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val lCleanA = newLabel(offset + programL.length + 1 + programR.length + 3)
@@ -187,7 +214,7 @@ trait CharCodecModule extends CodecModule {
                   VM.Pop,                        // clean up left
                   VM.Pop,
                   VM.Pop,
-                  VM.Push(NoValue),
+                  VM.Push(newValue(NoValue)),
                   VM.Return(name)                // exit
                 )
               // format: on
@@ -196,11 +223,11 @@ trait CharCodecModule extends CodecModule {
               val program = Array(
                 VM.BeginMethod(name),
                 VM.InputIdxPush,
-                VM.New(VM.AInstance(UUID.randomUUID(), "scala/Some")),
+                VM.New(VM.ANew(UUID.randomUUID(), "scala/Some")),
                 VM.Duplicate
               ) ++ compile(value(), offset + 4, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val lNone = newLabel(offset + program.length + 5)
@@ -219,7 +246,7 @@ trait CharCodecModule extends CodecModule {
                 VM.Pop,
                 VM.Pop,
                 VM.InputIdxPopSet,
-                VM.Push(None),
+                VM.Push(newValue(None)),
                 VM.Return(name)                  // exit
               )
               // format: on
@@ -230,12 +257,12 @@ trait CharCodecModule extends CodecModule {
                 VM.InputIdxPush
               ) ++ compile(left(), offset + 2, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val programR = compile(right(), offset + programL.length + 3, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val lAcceptL = newLabel(offset + programL.length + 3 + programR.length + 3)
@@ -262,11 +289,11 @@ trait CharCodecModule extends CodecModule {
             case Codec.Rep(value, None, None) =>
               val program = Array(
                 VM.BeginMethod(name),
-                VM.Push(Chunk.empty),
+                VM.Push(newValue(Chunk.empty)),
                 VM.InputIdxPush // repeat
               ) ++ compile(value(), offset + 3, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val lRepeat = newLabel(offset + 2)
@@ -292,11 +319,11 @@ trait CharCodecModule extends CodecModule {
               val program = Array(
                 VM.BeginMethod(name),
                 VM.PushInt(0),
-                VM.Push(Chunk.empty),
+                VM.Push(newValue(Chunk.empty)),
                 VM.InputIdxPush // repeat
               ) ++ compile(value(), offset + 4, chain1) ++ Array(
                 VM.Duplicate,
-                VM.Push(NoValue)
+                VM.Push(newValue(NoValue))
               )
 
               val lRepeat  = newLabel(offset + 3)
@@ -329,7 +356,7 @@ trait CharCodecModule extends CodecModule {
                 VM.InputIdxPopSet,
                 VM.Pop,
                 VM.Pop,
-                VM.Push(NoValue),
+                VM.Push(newValue(NoValue)),
                 VM.Return(name)                  // exit
               )
               // format: on
@@ -353,7 +380,7 @@ trait CharCodecModule extends CodecModule {
       case i                        => i
     }
 
-    (ret1, labels, sets)
+    CodecCompilationResult(ret1, labels, values, sets)
   }
 
   private def interpret(input: Chunk[Input], program: Array[CodecVM]): Either[DecodeError, (Int, Any)] = {
@@ -366,8 +393,8 @@ trait CharCodecModule extends CodecModule {
 
     def stackPopResolve(): AnyRef =
       stack.pop() match {
-        case AInstance(id, _) => createdInstances(id)
-        case value            => value
+        case ANew(id, _) => createdInstances(id)
+        case value       => value
       }
 
     var inputIndex: Int  = -1
@@ -401,7 +428,7 @@ trait CharCodecModule extends CodecModule {
           inputIndex = stack.pop().asInstanceOf[Int]
           i += 1
 
-        case Push(value) =>
+        case Push(AValue(_, value)) =>
           stack.push(value)
           i += 1
 
@@ -427,7 +454,7 @@ trait CharCodecModule extends CodecModule {
         case ACmpNe(ALabel(_, address)) =>
           if (stackPopResolve().eq(stackPopResolve())) i += 1 else i = address
 
-        case New(ins @ AInstance(id, _)) =>
+        case New(ins @ ANew(id, _)) =>
           createdInstances += (id -> null.asInstanceOf[AnyRef])
           stack.push(ins)
           i += 1
@@ -459,15 +486,15 @@ trait CharCodecModule extends CodecModule {
           i = address
 
         case InvokeSpecial1(_, _, _, f) =>
-          val arg1             = stackPopResolve()
-          val AInstance(id, _) = stack.pop()
+          val arg1        = stackPopResolve()
+          val ANew(id, _) = stack.pop()
           createdInstances += (id -> f(arg1))
           i += 1
 
         case InvokeSpecial2(_, _, _, f) =>
-          val arg2             = stackPopResolve()
-          val arg1             = stackPopResolve()
-          val AInstance(id, _) = stack.pop()
+          val arg2        = stackPopResolve()
+          val arg1        = stackPopResolve()
+          val ANew(id, _) = stack.pop()
           createdInstances += (id -> f(arg1, arg2))
           i += 1
 
@@ -524,6 +551,7 @@ trait CharCodecModule extends CodecModule {
   private def compileCodecVM(
     instructions: Array[CodecVM],
     addresses: Map[Int, Int],
+    values: Array[AnyRef],
     lookups: Array[java.util.HashSet[Any]]
   ): (String, Array[Byte]) = {
     import CodecVM._
@@ -534,20 +562,38 @@ trait CharCodecModule extends CodecModule {
     val labelAddresses: Map[Int, List[Label]] =
       labels.groupBy(_._2._2).map { case (address, list) => (address, list.toList.map(_._2._1)) }
 
+    def m_pushInt(m: MethodVisitor, i: Int): Unit =
+      i match {
+        case 0                              => m.visitInsn(ICONST_0)
+        case 1                              => m.visitInsn(ICONST_1)
+        case 2                              => m.visitInsn(ICONST_2)
+        case 3                              => m.visitInsn(ICONST_3)
+        case b if -128 <= b && b <= 127     => m.visitIntInsn(BIPUSH, b)
+        case s if -32768 <= s && s <= 32767 => m.visitIntInsn(SIPUSH, s)
+        case i                              => m.visitLdcInsn(i)
+      }
+
     val c: ClassWriter = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES)
     val name: String   = "MyCodec"
 
     c.visit(V1_8, ACC_PUBLIC | ACC_SUPER, name, null, "java/lang/Object", null)
 
     val m: MethodVisitor =
-      c.visitMethod(ACC_PUBLIC | ACC_STATIC, "run", "([Ljava/lang/Object;[C)Ljava/lang/Object;", null, null)
+      c.visitMethod(
+        ACC_PUBLIC | ACC_STATIC,
+        "run",
+        "([Ljava/lang/Object;[Ljava/util/HashSet;[C)Ljava/lang/Object;",
+        null,
+        null
+      )
     m.visitCode()
 
-    // var0: Array[Object] - NoValue followed by inclusion Sets
-    // var1: Array[char]   - input
-    // var2: int           - input index
+    // var0: Array[Object]  - external values
+    // var1: Array[HashSet] - inclusion sets
+    // var2: Array[char]    - input
+    // var3: int            - input index
     m.visitInsn(ICONST_M1)
-    m.visitVarInsn(ISTORE, 2)
+    m.visitVarInsn(ISTORE, 3)
 
     instructions.zipWithIndex.foreach {
       case (ins, address) =>
@@ -560,22 +606,22 @@ trait CharCodecModule extends CodecModule {
             val labelNoInput = new Label()
             val labelDone    = new Label()
 
-            m.visitIincInsn(2, 1)
+            m.visitIincInsn(3, 1)
 
-            m.visitVarInsn(ILOAD, 2)
-            m.visitVarInsn(ALOAD, 1)
+            m.visitVarInsn(ILOAD, 3)
+            m.visitVarInsn(ALOAD, 2)
             m.visitInsn(ARRAYLENGTH);
             m.visitJumpInsn(IF_ICMPGE, labelNoInput)
 
-            m.visitVarInsn(ALOAD, 1)
-            m.visitVarInsn(ILOAD, 2)
+            m.visitVarInsn(ALOAD, 2)
+            m.visitVarInsn(ILOAD, 3)
             m.visitInsn(CALOAD)
             m.visitMethodInsn(INVOKESTATIC, "java/lang/Character", "valueOf", "(C)Ljava/lang/Character;", false)
             m.visitJumpInsn(GOTO, labelDone)
 
             m.visitLabel(labelNoInput)
             m.visitVarInsn(ALOAD, 0)
-            m.visitInsn(ICONST_0)
+            m.visitInsn(ICONST_0) // todo: do not assume NoValue is first, use PushNoValue
             m.visitInsn(AALOAD)
 
             m.visitLabel(labelDone)
@@ -584,36 +630,31 @@ trait CharCodecModule extends CodecModule {
             ???
 
           case InputIdxPush =>
-            m.visitVarInsn(ILOAD, 2)
+            m.visitVarInsn(ILOAD, 3)
 
           case InputIdxPop =>
             m.visitInsn(POP)
 
           case InputIdxPopSet =>
-            m.visitVarInsn(ISTORE, 2)
+            m.visitVarInsn(ISTORE, 3)
 
-          case Push(NoValue) =>
+          case Push(AValue(0, NoValue)) =>
             m.visitVarInsn(ALOAD, 0)
             m.visitInsn(ICONST_0)
             m.visitInsn(AALOAD)
 
-          case Push(value) =>
-            ???
+          case Push(AValue(idx, _)) =>
+            m.visitVarInsn(ALOAD, 0)
+            m_pushInt(m, idx)
+            m.visitInsn(AALOAD)
 
           case PushInt(int) =>
-            int match {
-              case 0                              => m.visitInsn(ICONST_0)
-              case 1                              => m.visitInsn(ICONST_1)
-              case b if -128 <= b && b <= 127     => m.visitIntInsn(BIPUSH, b)
-              case s if -32768 <= s && s <= 32767 => m.visitIntInsn(SIPUSH, s)
-              case i                              => m.visitLdcInsn(i)
-            }
+            m_pushInt(m, int)
 
           case CheckSet(ASet(idx, _)) =>
-            m.visitVarInsn(ALOAD, 0)
-            m.visitLdcInsn(idx + 1) // todo: should be from another array
+            m.visitVarInsn(ALOAD, 1)
+            m_pushInt(m, idx)
             m.visitInsn(AALOAD)
-            m.visitTypeInsn(CHECKCAST, "java/util/HashSet");
 
             m.visitInsn(SWAP)
             m.visitMethodInsn(INVOKEVIRTUAL, "java/util/HashSet", "contains", "(Ljava/lang/Object;)Z", false);
@@ -633,7 +674,7 @@ trait CharCodecModule extends CodecModule {
           case Call1(f) => ???
           case Call2(f) => ???
 
-          case New(AInstance(_, owner)) =>
+          case New(ANew(_, owner)) =>
             m.visitTypeInsn(NEW, owner)
 
           case InvokeSpecial1(owner, name, args, _) =>

--- a/src/main/scala/zio/codec/CodecModule.scala
+++ b/src/main/scala/zio/codec/CodecModule.scala
@@ -1,5 +1,6 @@
 package zio.codec
 
+import com.github.ghik.silencer.silent
 import zio.Chunk
 
 trait CodecModule {
@@ -72,7 +73,7 @@ trait CodecModule {
     private[zio]       case object Consume                                                           extends Codec[Input]
     private[zio] sealed case class Map[A, B](equiv: Equiv[A, B], value: () => Codec[A])              extends Codec[B]
     private[zio] sealed case class Filter[A](value: () => Codec[A], filter: Set[A], mod: FilterMode) extends Codec[A]
-                                   { val hs: java.util.HashSet[Any] = new java.util.HashSet[Any](filter.asJava) }
+                                   { @silent val hs: java.util.HashSet[Any] = new java.util.HashSet[Any](filter.asJava) }
     private[zio] sealed case class Zip[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[(A, B)]
     private[zio] sealed case class Opt[A](value: () => Codec[A])                                     extends Codec[Option[A]]
     private[zio] sealed case class Alt[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[Either[A, B]]

--- a/src/main/scala/zio/codec/CodecModule.scala
+++ b/src/main/scala/zio/codec/CodecModule.scala
@@ -66,11 +66,13 @@ trait CodecModule {
 
   // format: off
   object Codec {
+    import scala.collection.JavaConverters._
     private[zio] sealed case class Produce[A](a: A)                                                  extends Codec[A]
     private[zio] sealed case class Fail[A](error: String)                                            extends Codec[A]
     private[zio]       case object Consume                                                           extends Codec[Input]
     private[zio] sealed case class Map[A, B](equiv: Equiv[A, B], value: () => Codec[A])              extends Codec[B]
     private[zio] sealed case class Filter[A](value: () => Codec[A], filter: Set[A], mod: FilterMode) extends Codec[A]
+                                   { val hs: java.util.HashSet[Any] = new java.util.HashSet[Any](filter.asJava) }
     private[zio] sealed case class Zip[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[(A, B)]
     private[zio] sealed case class Opt[A](value: () => Codec[A])                                     extends Codec[Option[A]]
     private[zio] sealed case class Alt[A, B](left: () => Codec[A], right: () => Codec[B])            extends Codec[Either[A, B]]

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -28,14 +28,16 @@ object CodecVM {
 
   private[zio] final case class Call1(f: AnyRef => AnyRef)                extends CodecVM // pop 1 thing, pass to f and push on stack
   private[zio] final case class Fail(err: String)                         extends CodecVM // exit with failure
-  private[zio] final case class BeginMethod(name: Int)                    extends CodecVM // denote start of a new method
-  private[zio] final case class Return(name: Int)                         extends CodecVM // return from method
-  private[zio] final case class InvokeStatic(name: Int, address: Int)     extends CodecVM // call a method
+  private[zio] final case class BeginMethod(name: String)                 extends CodecVM // beginning of a new method
+  private[zio] final case class EndMethod(name: String)                   extends CodecVM // end of a method
+  private[zio] final case class InvokeStatic(name: String, address: Int)  extends CodecVM // call a method
 
   private[zio] final case class New(ins: ANew)                            extends CodecVM // creates new instance, push reference on stack
+  private[zio] final case class CheckCast(owner: String)                  extends CodecVM // check if value on the stack is of certain type
   private[zio] final case class InvokeSpecial1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop args and instance and invoke constructor
   private[zio] final case class InvokeSpecial2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef)   extends CodecVM // pop args and instance and invoke constructor
-  private[zio] final case class InvokeInterface2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop args and instance and invoke interface
+  private[zio] final case class InvokeVirtual1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop args and instance and invoke virtual method
+  private[zio] final case class InvokeInterface2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop args and instance and invoke interface method
 
   private[zio] final case object Noop                                     extends CodecVM // do nothing
   private[zio] final case object Pop                                      extends CodecVM // pop 1 thing

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -4,10 +4,12 @@ sealed trait CodecVM
 
 object CodecVM {
   private[zio] final case class ALabel(num: Int, address: Int)
+  private[zio] final case class ASet(num: Int, set: Set[Any])
 
   private[zio] final case class Read(min: Option[Int], max: Option[Int])  extends CodecVM // read from input, push to stack
   private[zio] final case class Push(value: AnyRef)                       extends CodecVM // push value
-  private[zio] final case class CheckSet(s: Set[Any])                     extends CodecVM // pot 1, test value is in set, push the result as boolean on the stack
+  private[zio] final case class PushInt(value: Int)                       extends CodecVM // push int value
+  private[zio] final case class CheckSet(s: ASet)                         extends CodecVM // pop 1, test value is in set, push the result as boolean on the stack
   private[zio] final case class Jump(label: ALabel)                       extends CodecVM // unconditional jump to new address
   private[zio] final case class ICmpEq(label: ALabel)                     extends CodecVM // pop 2 integers and jump to new address if they are equal
   private[zio] final case class ACmpEq(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are equal

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -10,7 +10,11 @@ object CodecVM {
   private[zio] final case class ASet(idx: Int, set: Set[Any])
   private[zio] final case class AInstance(id: UUID, owner: String)
 
-  private[zio] final case class Read(min: Option[Int], max: Option[Int])  extends CodecVM // read from input, push to stack
+  private[zio] final case class  InputRead(min: Option[Int], max: Option[Int]) extends CodecVM // read from input, push to stack
+  private[zio] final case object InputIdxPush                                  extends CodecVM // push read index value to stack
+  private[zio] final case object InputIdxPop                                   extends CodecVM // pop read index value from stack
+  private[zio] final case object InputIdxPopSet                                extends CodecVM // pop read index value from stack and assign to read index
+
   private[zio] final case class Push(value: AnyRef)                       extends CodecVM // push value
   private[zio] final case class PushInt(value: Int)                       extends CodecVM // push int value
   private[zio] final case class CheckSet(set: ASet)                       extends CodecVM // pop 1, test value is in set, push the result as boolean on the stack
@@ -30,11 +34,9 @@ object CodecVM {
   private[zio] final case object Noop                                     extends CodecVM // do nothing
   private[zio] final case object Pop                                      extends CodecVM // pop 1 thing
   private[zio] final case object Duplicate                                extends CodecVM // duplicate stack head
+  private[zio] final case object Swap                                     extends CodecVM // swap 2 operands at the top of the stack
   private[zio] final case object StoreRegister0                           extends CodecVM // pop 1 thing from stack and store in var 0
   private[zio] final case object LoadRegister0                            extends CodecVM // push var 0
   private[zio] final case object IAdd                                     extends CodecVM // pop 2 integers, add, push result
-  private[zio] final case object IIndexPush                               extends CodecVM // push read index to stack
-  private[zio] final case object IIndexPop                                extends CodecVM // pop read index from stack
-  private[zio] final case object IIndexStore                              extends CodecVM // pop read index from stack and assign to read index
   // format: on
 }

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -12,13 +12,14 @@ object CodecVM {
   private[zio] final case class ANew(id: UUID, owner: String)
 
   private[zio] final case class  InputRead(min: Option[Int], max: Option[Int]) extends CodecVM // read from input, push to stack
-  private[zio] final case object InputIdxPush                                  extends CodecVM // push read index value to stack
+  private[zio] final case object InputIdxLoad                                  extends CodecVM // push read index value to stack
   private[zio] final case object InputIdxPop                                   extends CodecVM // pop read index value from stack
-  private[zio] final case object InputIdxPopSet                                extends CodecVM // pop read index value from stack and assign to read index
+  private[zio] final case object InputIdxStore                                 extends CodecVM // pop read index value from stack and assign to read index
 
-  private[zio] final case class Push(value: AValue)                       extends CodecVM // push value to stack
-  private[zio] final case class PushInt(value: Int)                       extends CodecVM // push int value to stack
-  private[zio] final case class CheckSet(set: ASet)                       extends CodecVM // pop 1, test if in the set, push the result as boolean to stack
+  private[zio] final case class  Push(value: AValue)                       extends CodecVM // push value to stack
+  private[zio] final case class  PushInt(value: Int)                       extends CodecVM // push int value to stack
+  private[zio] final case object PushNoValue                               extends CodecVM // push NoValue to stack
+  private[zio] final case class  CheckSet(set: ASet)                       extends CodecVM // pop 1, test if in the set, push the result as boolean to stack
 
   private[zio] final case class Jump(label: ALabel)                       extends CodecVM // unconditional jump to new address
   private[zio] final case class ICmpEq(label: ALabel)                     extends CodecVM // pop 2 integers and jump to new address if they are equal

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -1,25 +1,32 @@
 package zio.codec
 
+import java.util.UUID
+
 sealed trait CodecVM
 
 object CodecVM {
-  private[zio] final case class ALabel(num: Int, address: Int)
-  private[zio] final case class ASet(num: Int, set: Set[Any])
+  // format: off
+  private[zio] final case class ALabel(idx: Int, address: Int)
+  private[zio] final case class ASet(idx: Int, set: Set[Any])
+  private[zio] final case class AInstance(id: UUID, owner: String)
 
   private[zio] final case class Read(min: Option[Int], max: Option[Int])  extends CodecVM // read from input, push to stack
   private[zio] final case class Push(value: AnyRef)                       extends CodecVM // push value
   private[zio] final case class PushInt(value: Int)                       extends CodecVM // push int value
-  private[zio] final case class CheckSet(s: ASet)                         extends CodecVM // pop 1, test value is in set, push the result as boolean on the stack
+  private[zio] final case class CheckSet(set: ASet)                       extends CodecVM // pop 1, test value is in set, push the result as boolean on the stack
   private[zio] final case class Jump(label: ALabel)                       extends CodecVM // unconditional jump to new address
   private[zio] final case class ICmpEq(label: ALabel)                     extends CodecVM // pop 2 integers and jump to new address if they are equal
   private[zio] final case class ACmpEq(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are equal
   private[zio] final case class ACmpNe(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are not equal
-  private[zio] final case class Construct1(f: AnyRef => AnyRef)           extends CodecVM // pop 1 thing, pass to f and push to stack
-  private[zio] final case class Construct2(f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop 2 things, pass to f and push to stack
+  private[zio] final case class New(ins: AInstance)                       extends CodecVM // creates new instance, push reference on stack
+  private[zio] final case class Call1(f: AnyRef => AnyRef)                extends CodecVM // pop 1 thing, pass to f and push on stack
+  private[zio] final case class Call2(f: (AnyRef, AnyRef) => AnyRef)      extends CodecVM // pop 2 things, pass to f and push on stack
   private[zio] final case class Fail(err: String)                         extends CodecVM // exit with failure
   private[zio] final case class BeginMethod(name: Int)                    extends CodecVM // denote start of a new method
   private[zio] final case class Return(name: Int)                         extends CodecVM // return from method
   private[zio] final case class InvokeStatic(name: Int, address: Int)     extends CodecVM // call a method
+  private[zio] final case class InvokeSpecial1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)           extends CodecVM // pop args and instance and invoke constructor
+  private[zio] final case class InvokeSpecial2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop args and instance and invoke constructor
   private[zio] final case object Noop                                     extends CodecVM // do nothing
   private[zio] final case object Pop                                      extends CodecVM // pop 1 thing
   private[zio] final case object Duplicate                                extends CodecVM // duplicate stack head
@@ -29,4 +36,5 @@ object CodecVM {
   private[zio] final case object IIndexPush                               extends CodecVM // push read index to stack
   private[zio] final case object IIndexPop                                extends CodecVM // pop read index from stack
   private[zio] final case object IIndexStore                              extends CodecVM // pop read index from stack and assign to read index
+  // format: on
 }

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -35,10 +35,13 @@ object CodecVM {
 
   private[zio] final case class New(ins: ANew)                            extends CodecVM // creates new instance, push reference on stack
   private[zio] final case class CheckCast(owner: String)                  extends CodecVM // check if value on the stack is of certain type
-  private[zio] final case class InvokeSpecial1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop args and instance and invoke constructor
-  private[zio] final case class InvokeSpecial2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef)   extends CodecVM // pop args and instance and invoke constructor
-  private[zio] final case class InvokeVirtual1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop args and instance and invoke virtual method
-  private[zio] final case class InvokeInterface2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop args and instance and invoke interface method
+  private[zio] final case class GetStatic(owner: String, name: String, desc: String, v: AnyRef)                            extends CodecVM // place value of the static field on the stack
+  private[zio] final case class InvokeSpecial1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop arg and instance, invoke constructor
+  private[zio] final case class InvokeSpecial2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef)   extends CodecVM // pop 2 args and instance, invoke constructor
+  private[zio] final case class InvokeVirtual0(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop instance, invoke virtual method
+  private[zio] final case class InvokeVirtual1(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef)   extends CodecVM // pop arg and instance, invoke virtual method
+  private[zio] final case class InvokeInterface0(owner: String, name: String, desc: String, f: AnyRef => AnyRef)           extends CodecVM // pop instance, invoke interface method
+  private[zio] final case class InvokeInterface1(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop arg and instance, invoke interface method
 
   private[zio] final case object Noop                                     extends CodecVM // do nothing
   private[zio] final case object Pop                                      extends CodecVM // pop 1 thing

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -26,15 +26,17 @@ object CodecVM {
   private[zio] final case class ACmpEq(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are equal
   private[zio] final case class ACmpNe(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are not equal
 
-  private[zio] final case class New(ins: ANew)                            extends CodecVM // creates new instance, push reference on stack
   private[zio] final case class Call1(f: AnyRef => AnyRef)                extends CodecVM // pop 1 thing, pass to f and push on stack
-  private[zio] final case class Call2(f: (AnyRef, AnyRef) => AnyRef)      extends CodecVM // pop 2 things, pass to f and push on stack
   private[zio] final case class Fail(err: String)                         extends CodecVM // exit with failure
   private[zio] final case class BeginMethod(name: Int)                    extends CodecVM // denote start of a new method
   private[zio] final case class Return(name: Int)                         extends CodecVM // return from method
   private[zio] final case class InvokeStatic(name: Int, address: Int)     extends CodecVM // call a method
-  private[zio] final case class InvokeSpecial1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)           extends CodecVM // pop args and instance and invoke constructor
-  private[zio] final case class InvokeSpecial2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop args and instance and invoke constructor
+
+  private[zio] final case class New(ins: ANew)                            extends CodecVM // creates new instance, push reference on stack
+  private[zio] final case class InvokeSpecial1(owner: String, name: String, desc: String, f: AnyRef => AnyRef)             extends CodecVM // pop args and instance and invoke constructor
+  private[zio] final case class InvokeSpecial2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef)   extends CodecVM // pop args and instance and invoke constructor
+  private[zio] final case class InvokeInterface2(owner: String, name: String, desc: String, f: (AnyRef, AnyRef) => AnyRef) extends CodecVM // pop args and instance and invoke interface
+
   private[zio] final case object Noop                                     extends CodecVM // do nothing
   private[zio] final case object Pop                                      extends CodecVM // pop 1 thing
   private[zio] final case object Duplicate                                extends CodecVM // duplicate stack head

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -26,7 +26,6 @@ object CodecVM {
   private[zio] final case class ACmpEq(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are equal
   private[zio] final case class ACmpNe(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are not equal
 
-  private[zio] final case class Call1(f: AnyRef => AnyRef)                extends CodecVM // pop 1 thing, pass to f and push on stack
   private[zio] final case class Fail(err: String)                         extends CodecVM // exit with failure
 
   private[zio] final case class BeginMethod(name: String)                 extends CodecVM // begin new method

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -8,21 +8,24 @@ object CodecVM {
   // format: off
   private[zio] final case class ALabel(idx: Int, address: Int)
   private[zio] final case class ASet(idx: Int, set: Set[Any])
-  private[zio] final case class AInstance(id: UUID, owner: String)
+  private[zio] final case class AValue(idx: Int, value: AnyRef)
+  private[zio] final case class ANew(id: UUID, owner: String)
 
   private[zio] final case class  InputRead(min: Option[Int], max: Option[Int]) extends CodecVM // read from input, push to stack
   private[zio] final case object InputIdxPush                                  extends CodecVM // push read index value to stack
   private[zio] final case object InputIdxPop                                   extends CodecVM // pop read index value from stack
   private[zio] final case object InputIdxPopSet                                extends CodecVM // pop read index value from stack and assign to read index
 
-  private[zio] final case class Push(value: AnyRef)                       extends CodecVM // push value
-  private[zio] final case class PushInt(value: Int)                       extends CodecVM // push int value
-  private[zio] final case class CheckSet(set: ASet)                       extends CodecVM // pop 1, test value is in set, push the result as boolean on the stack
+  private[zio] final case class Push(value: AValue)                       extends CodecVM // push value to stack
+  private[zio] final case class PushInt(value: Int)                       extends CodecVM // push int value to stack
+  private[zio] final case class CheckSet(set: ASet)                       extends CodecVM // pop 1, test if in the set, push the result as boolean to stack
+
   private[zio] final case class Jump(label: ALabel)                       extends CodecVM // unconditional jump to new address
   private[zio] final case class ICmpEq(label: ALabel)                     extends CodecVM // pop 2 integers and jump to new address if they are equal
   private[zio] final case class ACmpEq(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are equal
   private[zio] final case class ACmpNe(label: ALabel)                     extends CodecVM // pop 2 references and jump to new address if they are not equal
-  private[zio] final case class New(ins: AInstance)                       extends CodecVM // creates new instance, push reference on stack
+
+  private[zio] final case class New(ins: ANew)                            extends CodecVM // creates new instance, push reference on stack
   private[zio] final case class Call1(f: AnyRef => AnyRef)                extends CodecVM // pop 1 thing, pass to f and push on stack
   private[zio] final case class Call2(f: (AnyRef, AnyRef) => AnyRef)      extends CodecVM // pop 2 things, pass to f and push on stack
   private[zio] final case class Fail(err: String)                         extends CodecVM // exit with failure

--- a/src/main/scala/zio/codec/CodecVM.scala
+++ b/src/main/scala/zio/codec/CodecVM.scala
@@ -28,9 +28,10 @@ object CodecVM {
 
   private[zio] final case class Call1(f: AnyRef => AnyRef)                extends CodecVM // pop 1 thing, pass to f and push on stack
   private[zio] final case class Fail(err: String)                         extends CodecVM // exit with failure
-  private[zio] final case class BeginMethod(name: String)                 extends CodecVM // beginning of a new method
-  private[zio] final case class EndMethod(name: String)                   extends CodecVM // end of a method
-  private[zio] final case class InvokeStatic(name: String, address: Int)  extends CodecVM // call a method
+
+  private[zio] final case class BeginMethod(name: String)                 extends CodecVM // begin new method
+  private[zio] final case class EndMethod(name: String)                   extends CodecVM // end new method
+  private[zio] final case class CallMethod(name: String, address: Int)    extends CodecVM // call method
 
   private[zio] final case class New(ins: ANew)                            extends CodecVM // creates new instance, push reference on stack
   private[zio] final case class CheckCast(owner: String)                  extends CodecVM // check if value on the stack is of certain type

--- a/src/main/scala/zio/codec/Equiv.scala
+++ b/src/main/scala/zio/codec/Equiv.scala
@@ -23,4 +23,7 @@ object Equiv {
   object Chars {
     final case object String extends Equiv[Chunk[Char], String]
   }
+
+  private[codec] def merge[A](arg: Either[A, A]): A =
+    arg.merge
 }

--- a/src/test/scala/zio/codec/examples/CodecJsonTest.scala
+++ b/src/test/scala/zio/codec/examples/CodecJsonTest.scala
@@ -115,7 +115,7 @@ object CodecJsonTest {
     println(dec(value))
 
     val t1: Long = System.nanoTime()
-    (1 to 10000).foreach { _ =>
+    (1 to 100000).foreach { _ =>
       dec(value)
     }
     val t2: Long = System.nanoTime() - t1
@@ -130,9 +130,9 @@ object CodecJsonTest {
   // 1,000,000  in 24.9 sec
 
   // zio-codec 0.0.1
-  //    10,000  in  2.2 sec
-  //   100,000  in 17.6 sec
-  // 1,000,000  in    ? sec
+  //    10,000  in  0.8 sec
+  //   100,000  in  4.1 sec
+  // 1,000,000  in 35.8 sec
 
   val value: Chunk[Char] =
     Chunk.fromArray("""{


### PR DESCRIPTION
Closes #5 

Added JVM bytecode generation for decoder. Switched all tests to use new implementation.

It is not as fast as I expected, see metrics in `CodecJsonTest.scala` 😐
